### PR TITLE
feature/UIScrollView

### DIFF
--- a/Sources/UIKitExtensions/UIScrollView.swift
+++ b/Sources/UIKitExtensions/UIScrollView.swift
@@ -1,0 +1,82 @@
+import UIKit
+
+public extension ConfigurationSet where Base: UIScrollView {
+    func delegate(_ delegate: UIScrollViewDelegate?) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.delegate = delegate
+        }
+    }
+    
+    func contentSize(_ contentSize: CGSize) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.contentSize = contentSize
+        }
+    }
+    
+    func contentOffset(_ contentOffset: CGPoint) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.contentOffset = contentOffset
+        }
+    }
+    
+    func contentInset(_ contentInset: UIEdgeInsets) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.contentInset = contentInset
+        }
+    }
+    
+    @available(iOS 11.0, *)
+    func contentInsetAdjustmentBehavior(_ contentInsetAdjustmentBehavior: UIScrollViewContentInsetAdjustmentBehavior) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.contentInsetAdjustmentBehavior = contentInsetAdjustmentBehavior
+        }
+    }
+    
+    func isScrollEnabled(_ isScrollEnabled: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.isScrollEnabled = isScrollEnabled
+        }
+    }
+    
+    func isDirectionalLockEnabled(_ isDirectionalLockEnabled: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.isDirectionalLockEnabled = isDirectionalLockEnabled
+        }
+    }
+    
+    func isPagingEnabled(_ isPagingEnabled: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.isPagingEnabled = isPagingEnabled
+        }
+    }
+    
+    func scrollsToTop(_ scrollsToTop: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.scrollsToTop = scrollsToTop
+        }
+    }
+    
+    func bounces(_ bounces: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.bounces = bounces
+        }
+    }
+    
+    func alwaysBounceVertical(_ alwaysBounceVertical: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.alwaysBounceVertical = alwaysBounceVertical
+        }
+    }
+    
+    func alwaysBounceHorizontal(_ alwaysBounceHorizontal: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.alwaysBounceHorizontal = alwaysBounceHorizontal
+        }
+    }
+    
+    func decelerationRate(_ decelerationRate: CGFloat) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.decelerationRate = decelerationRate
+        }
+    }
+}

--- a/Sources/UIKitExtensions/UIScrollView.swift
+++ b/Sources/UIKitExtensions/UIScrollView.swift
@@ -79,4 +79,83 @@ public extension ConfigurationSet where Base: UIScrollView {
             scrollView.decelerationRate = decelerationRate
         }
     }
+    
+    func indicatorStyle(_ indicatorStyle: UIScrollViewIndicatorStyle) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.indicatorStyle = indicatorStyle
+        }
+    }
+    
+    func scrollIndicatorInsets(_ scrollIndicatorInsets: UIEdgeInsets) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.scrollIndicatorInsets = scrollIndicatorInsets
+        }
+    }
+    
+    func showsVerticalScrollIndicator(_ showsVerticalScrollIndicator: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.showsVerticalScrollIndicator = showsVerticalScrollIndicator
+        }
+    }
+    
+    func showsHorizontalScrollIndicator(_ showsHorizontalScrollIndicator: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.showsHorizontalScrollIndicator = showsHorizontalScrollIndicator
+        }
+    }
+    
+    @available(iOS 10.0, *)
+    func refreshControl(_ refreshControl: UIRefreshControl?) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.refreshControl = refreshControl
+        }
+    }
+    
+    func canCancelContentTouches(_ canCancelContentTouches: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.canCancelContentTouches = canCancelContentTouches
+        }
+    }
+    
+    func delaysContentTouches(_ delaysContentTouches: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.delaysContentTouches = delaysContentTouches
+        }
+    }
+    
+    func zoomScale(_ zoomScale: CGFloat) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.zoomScale = zoomScale
+        }
+    }
+    
+    func minimumZoomScale(_ minimumZoomScale: CGFloat) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.minimumZoomScale = minimumZoomScale
+        }
+    }
+    
+    func maximumZoomScale(_ maximumZoomScale: CGFloat) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.maximumZoomScale = maximumZoomScale
+        }
+    }
+    
+    func bouncesZoom(_ bouncesZoom: Bool) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.bouncesZoom = bouncesZoom
+        }
+    }
+    
+    func keyboardDismissMode(_ keyboardDismissMode: UIScrollViewKeyboardDismissMode) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.keyboardDismissMode = keyboardDismissMode
+        }
+    }
+    
+    func indexDisplayMode(_ indexDisplayMode: UIScrollViewIndexDisplayMode) -> ConfigurationSet<Base> {
+        return set { (scrollView: Base) in
+            scrollView.indexDisplayMode = indexDisplayMode
+        }
+    }
 }

--- a/Sources/UIKitExtensions/UIScrollView.swift
+++ b/Sources/UIKitExtensions/UIScrollView.swift
@@ -123,6 +123,35 @@ public extension ConfigurationSet where Base: UIScrollView {
         }
     }
     
+    /**
+     - note: This method only has the desired effect if applied after the scroll view gets a `delegate`, and the delegate's class
+     must implement the method `viewForZooming(in scrollView: UIScrollView)`. Also, note that the `zoomScale` property of
+     the scroll view does not necessarily get set to the value of the parameter `zoomScale`, but rather to value in the interval
+     `[minimumZoomScale, maximumZoomScale]` that is closest to this parameter. Since both `minimumZoomScale` and `maximumZoomScale`
+     have default value 1.0, setting the `zoomScale` before changing them will have no effect.
+     
+     These remarks are not specific to the `ConfigurationSet.zoomScale` method but rather general observations about the behavior of
+     the `UIScrollView` class. Remember that `ConfigurationSet` applies concatenated configurations in the order they appear, so you
+     can successfully set the `zoomScale` with a single `build` call as follows:
+     
+     ```
+     class MyDelegate: NSObject, UIScrollViewDelegate {
+         let zoomView = UIView()
+         func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+             return zoomView
+         }
+     }
+
+     let delegate = MyDelegate()
+     let scrollView = UIScrollView.build { set in
+         set
+             .delegate(delegate)
+             .minimumZoomScale(3.14)
+             .maximumZoomScale(99.9)
+             .zoomScale(42.0)
+     }
+     ```
+     */
     func zoomScale(_ zoomScale: CGFloat) -> ConfigurationSet<Base> {
         return set { (scrollView: Base) in
             scrollView.zoomScale = zoomScale

--- a/Tests/UIScrollViewSpecs.swift
+++ b/Tests/UIScrollViewSpecs.swift
@@ -5,6 +5,127 @@ import ViewConfigurator
 class UIScrollViewSpecs: QuickSpec {
     override func spec() {
         describe("UIViewConfigurator") {
+            it("can set delegate") {
+                class DummyScrollViewDelegate: NSObject, UIScrollViewDelegate {}
+                let dummyDelegate = DummyScrollViewDelegate()
+                let testView: UIScrollView = .build { set in
+                    set.delegate(dummyDelegate)
+                }
+                expect(testView.delegate).to(be(dummyDelegate))
+            }
+            it("can set contentSize") {
+                let size = CGSize(width: 42, height: 99)
+                let testView: UIScrollView = .build { set in
+                    set.contentSize(size)
+                }
+                expect(testView.contentSize).to(equal(size))
+            }
+            it("can set contentOffset") {
+                let offset = CGPoint(x: 42, y: 99)
+                let testView: UIScrollView = .build { set in
+                    set.contentOffset(offset)
+                }
+                expect(testView.contentOffset).to(equal(offset))
+            }
+            it("can set contentInset") {
+                let inset = UIEdgeInsets(top: 42.0, left: 43.0, bottom: 44.0, right: 45.0)
+                let testView: UIScrollView = .build { set in
+                    set.contentInset(inset)
+                }
+                expect(testView.contentInset).to(equal(inset))
+            }
+            if #available(iOS 11.0, *) {
+                it("can set contentInsetAdjustmentBehavior") {
+                    let behaviorNever = UIScrollViewContentInsetAdjustmentBehavior.never
+                    let testViewNever: UIScrollView = .build { set in
+                        set.contentInsetAdjustmentBehavior(behaviorNever)
+                    }
+                    expect(testViewNever.contentInsetAdjustmentBehavior).to(equal(behaviorNever))
+                    
+                    let behaviorAlways = UIScrollViewContentInsetAdjustmentBehavior.always
+                    let testViewAlways: UIScrollView = .build { set in
+                        set.contentInsetAdjustmentBehavior(behaviorAlways)
+                    }
+                    expect(testViewAlways.contentInsetAdjustmentBehavior).to(equal(behaviorAlways))
+                }
+            }
+            it("can set isScrollEnabled") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.isScrollEnabled(false)
+                }
+                expect(testViewFalse.isScrollEnabled).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.isScrollEnabled(true)
+                }
+                expect(testViewTrue.isScrollEnabled).to(equal(true))
+            }
+            it("can set isDirectionalLockEnabled") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.isDirectionalLockEnabled(false)
+                }
+                expect(testViewFalse.isDirectionalLockEnabled).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.isDirectionalLockEnabled(true)
+                }
+                expect(testViewTrue.isDirectionalLockEnabled).to(equal(true))
+            }
+            it("can set isPagingEnabled") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.isPagingEnabled(false)
+                }
+                expect(testViewFalse.isPagingEnabled).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.isPagingEnabled(true)
+                }
+                expect(testViewTrue.isPagingEnabled).to(equal(true))
+            }
+            it("can set scrollsToTop") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.scrollsToTop(false)
+                }
+                expect(testViewFalse.scrollsToTop).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.scrollsToTop(true)
+                }
+                expect(testViewTrue.scrollsToTop).to(equal(true))
+            }
+            it("can set bounces") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.bounces(false)
+                }
+                expect(testViewFalse.bounces).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.bounces(true)
+                }
+                expect(testViewTrue.bounces).to(equal(true))
+            }
+            it("can set alwaysBounceVertical") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.alwaysBounceVertical(false)
+                }
+                expect(testViewFalse.alwaysBounceVertical).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.alwaysBounceVertical(true)
+                }
+                expect(testViewTrue.alwaysBounceVertical).to(equal(true))
+            }
+            it("can set alwaysBounceHorizontal") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.alwaysBounceHorizontal(false)
+                }
+                expect(testViewFalse.alwaysBounceHorizontal).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.alwaysBounceHorizontal(true)
+                }
+                expect(testViewTrue.alwaysBounceHorizontal).to(equal(true))
+            }
         }
     }
 }

--- a/Tests/UIScrollViewSpecs.swift
+++ b/Tests/UIScrollViewSpecs.swift
@@ -126,6 +126,150 @@ class UIScrollViewSpecs: QuickSpec {
                 }
                 expect(testViewTrue.alwaysBounceHorizontal).to(equal(true))
             }
+            it("can set decelerationRate") {
+                let rateNormal = UIScrollViewDecelerationRateNormal
+                let testViewNormal: UIScrollView = .build { set in
+                    set.decelerationRate(rateNormal)
+                }
+                expect(testViewNormal.decelerationRate).to(equal(rateNormal))
+                
+                let rateFast = UIScrollViewDecelerationRateNormal
+                let testViewFast: UIScrollView = .build { set in
+                    set.decelerationRate(rateFast)
+                }
+                expect(testViewFast.decelerationRate).to(equal(rateFast))
+            }
+            it("can set indicatorStyle") {
+                let styleBlack = UIScrollViewIndicatorStyle.black
+                let testViewBlack: UIScrollView = .build { set in
+                    set.indicatorStyle(styleBlack)
+                }
+                expect(testViewBlack.indicatorStyle).to(equal(styleBlack))
+                
+                let styleWhite = UIScrollViewIndicatorStyle.white
+                let testViewWhite: UIScrollView = .build { set in
+                    set.indicatorStyle(styleWhite)
+                }
+                expect(testViewWhite.indicatorStyle).to(equal(styleWhite))
+            }
+            it("can set scrollIndicatorInsets") {
+                let inset = UIEdgeInsets(top: 42.0, left: 43.0, bottom: 44.0, right: 45.0)
+                let testView: UIScrollView = .build { set in
+                    set.scrollIndicatorInsets(inset)
+                }
+                expect(testView.scrollIndicatorInsets).to(equal(inset))
+            }
+            it("can set showsVerticalScrollIndicator") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.showsVerticalScrollIndicator(false)
+                }
+                expect(testViewFalse.showsVerticalScrollIndicator).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.showsVerticalScrollIndicator(true)
+                }
+                expect(testViewTrue.showsVerticalScrollIndicator).to(equal(true))
+            }
+            it("can set showsHorizontalScrollIndicator") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.showsHorizontalScrollIndicator(false)
+                }
+                expect(testViewFalse.showsHorizontalScrollIndicator).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.showsHorizontalScrollIndicator(true)
+                }
+                expect(testViewTrue.showsHorizontalScrollIndicator).to(equal(true))
+            }
+            if #available(iOS 10.0, *) {
+                it("can set refreshControl") {
+                    let control = UIRefreshControl()
+                    let testView: UIScrollView = .build { set in
+                        set.refreshControl(control)
+                    }
+                    expect(testView.refreshControl).to(be(control))
+                }
+            }
+            it("can set canCancelContentTouches") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.canCancelContentTouches(false)
+                }
+                expect(testViewFalse.canCancelContentTouches).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.canCancelContentTouches(true)
+                }
+                expect(testViewTrue.canCancelContentTouches).to(equal(true))
+            }
+            it("can set delaysContentTouches") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.delaysContentTouches(false)
+                }
+                expect(testViewFalse.delaysContentTouches).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.delaysContentTouches(true)
+                }
+                expect(testViewTrue.delaysContentTouches).to(equal(true))
+            }
+            it("can set zoomScale") {
+                let scale: CGFloat = 42.0
+                let testView: UIScrollView = .build { set in
+                    set.zoomScale(scale)
+                }
+                expect(testView.zoomScale).to(equal(scale))
+            }
+            it("can set minimumZoomScale") {
+                let scale: CGFloat = 42.0
+                let testView: UIScrollView = .build { set in
+                    set.minimumZoomScale(scale)
+                }
+                expect(testView.minimumZoomScale).to(equal(scale))
+            }
+            it("can set maximumZoomScale") {
+                let scale: CGFloat = 42.0
+                let testView: UIScrollView = .build { set in
+                    set.maximumZoomScale(scale)
+                }
+                expect(testView.maximumZoomScale).to(equal(scale))
+            }
+            it("can set bouncesZoom") {
+                let testViewFalse: UIScrollView = .build { set in
+                    set.bouncesZoom(false)
+                }
+                expect(testViewFalse.bouncesZoom).to(equal(false))
+                
+                let testViewTrue: UIScrollView = .build { set in
+                    set.bouncesZoom(true)
+                }
+                expect(testViewTrue.bouncesZoom).to(equal(true))
+            }
+            it("can set keyboardDismissMode") {
+                let modeInteractive = UIScrollViewKeyboardDismissMode.interactive
+                let testViewInteractive: UIScrollView = .build { set in
+                    set.keyboardDismissMode(modeInteractive)
+                }
+                expect(testViewInteractive.keyboardDismissMode).to(equal(modeInteractive))
+                
+                let modeOnDrag = UIScrollViewKeyboardDismissMode.onDrag
+                let testViewOnDrag: UIScrollView = .build { set in
+                    set.keyboardDismissMode(modeOnDrag)
+                }
+                expect(testViewOnDrag.keyboardDismissMode).to(equal(modeOnDrag))
+            }
+            it("can set indexDisplayMode") {
+                let modeHidden = UIScrollViewIndexDisplayMode.alwaysHidden
+                let testViewHidden: UIScrollView = .build { set in
+                    set.indexDisplayMode(modeHidden)
+                }
+                expect(testViewHidden.indexDisplayMode).to(equal(modeHidden))
+                
+                let modeAutomatic = UIScrollViewIndexDisplayMode.automatic
+                let testViewAutomatic: UIScrollView = .build { set in
+                    set.indexDisplayMode(modeAutomatic)
+                }
+                expect(testViewAutomatic.indexDisplayMode).to(equal(modeAutomatic))
+            }
         }
     }
 }

--- a/Tests/UIScrollViewSpecs.swift
+++ b/Tests/UIScrollViewSpecs.swift
@@ -213,9 +213,20 @@ class UIScrollViewSpecs: QuickSpec {
                 expect(testViewTrue.delaysContentTouches).to(equal(true))
             }
             it("can set zoomScale") {
+                class DummyScrollViewDelegate: NSObject, UIScrollViewDelegate {
+                    let zoomView = UIView()
+                    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+                        return zoomView
+                    }
+                }
+                let dummyDelegate = DummyScrollViewDelegate()
                 let scale: CGFloat = 42.0
+                let maximum: CGFloat = 100.0
                 let testView: UIScrollView = .build { set in
-                    set.zoomScale(scale)
+                    set
+                        .delegate(dummyDelegate)
+                        .maximumZoomScale(maximum)
+                        .zoomScale(scale)
                 }
                 expect(testView.zoomScale).to(equal(scale))
             }

--- a/Tests/UIScrollViewSpecs.swift
+++ b/Tests/UIScrollViewSpecs.swift
@@ -1,0 +1,10 @@
+import Quick
+import Nimble
+import ViewConfigurator
+
+class UIScrollViewSpecs: QuickSpec {
+    override func spec() {
+        describe("UIViewConfigurator") {
+        }
+    }
+}

--- a/ViewConfigurator.xcodeproj/project.pbxproj
+++ b/ViewConfigurator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		7C59413E1FB9A0C2002F10CE /* Enableable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C59413D1FB9A0C2002F10CE /* Enableable.swift */; };
 		7C5941401FB9A326002F10CE /* UIActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C59413F1FB9A325002F10CE /* UIActivityIndicatorView.swift */; };
 		7C8A4A011FFBD12B00C69F3C /* UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A4A001FFBD12B00C69F3C /* UIScrollView.swift */; };
+		7C8A4A151FFBEC1200C69F3C /* UIScrollViewSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A4A131FFBEB4A00C69F3C /* UIScrollViewSpecs.swift */; };
 		7C9760FB1FB9A68900DC0BF8 /* UIActivityIndicatorViewSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5941411FB9A3FD002F10CE /* UIActivityIndicatorViewSpecs.swift */; };
 		E409D8E71F2BB3F0004964AE /* Configurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E409D8E61F2BB3F0004964AE /* Configurator.swift */; };
 		E43951751F2C7DFB00543B34 /* UIViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43951661F2C7C9800543B34 /* UIViewSpec.swift */; };
@@ -223,6 +224,7 @@
 		7C59413F1FB9A325002F10CE /* UIActivityIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorView.swift; sourceTree = "<group>"; };
 		7C5941411FB9A3FD002F10CE /* UIActivityIndicatorViewSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorViewSpecs.swift; sourceTree = "<group>"; };
 		7C8A4A001FFBD12B00C69F3C /* UIScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollView.swift; sourceTree = "<group>"; };
+		7C8A4A131FFBEB4A00C69F3C /* UIScrollViewSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewSpecs.swift; sourceTree = "<group>"; };
 		E409D8E61F2BB3F0004964AE /* Configurator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configurator.swift; sourceTree = "<group>"; };
 		E43951661F2C7C9800543B34 /* UIViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewSpec.swift; sourceTree = "<group>"; };
 		E44F9F4C1F2C9EC500D2683D /* CALayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayer.swift; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 				E4A317A51F56FA1600649294 /* UIControlSpecs.swift */,
 				E4EA60301F69868A00A2BF3A /* UIImageViewSpecs.swift */,
 				E4EC0D811F56C2FD0053621D /* UILabelSpecs.swift */,
+				7C8A4A131FFBEB4A00C69F3C /* UIScrollViewSpecs.swift */,
 				E43951661F2C7C9800543B34 /* UIViewSpec.swift */,
 			);
 			path = Tests;
@@ -488,8 +491,8 @@
 				E4A317921F56F9E300649294 /* UIControl.swift */,
 				E4EA601C1F69834400A2BF3A /* UIImageView.swift */,
 				E4EC0D6C1F56C1E30053621D /* UILabel.swift */,
-				E45B54231F2BBBA1001F20E3 /* UIView.swift */,
 				7C8A4A001FFBD12B00C69F3C /* UIScrollView.swift */,
+				E45B54231F2BBBA1001F20E3 /* UIView.swift */,
 			);
 			path = UIKitExtensions;
 			sourceTree = "<group>";
@@ -791,6 +794,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7C8A4A151FFBEC1200C69F3C /* UIScrollViewSpecs.swift in Sources */,
 				7C9760FB1FB9A68900DC0BF8 /* UIActivityIndicatorViewSpecs.swift in Sources */,
 				E45621481F5718E000FBD730 /* UIButtonSpecs.swift in Sources */,
 				E4FEB6601F2CA00700EE6D8C /* LayerContainingSpecs.swift in Sources */,

--- a/ViewConfigurator.xcodeproj/project.pbxproj
+++ b/ViewConfigurator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		7C59413C1FB9A0B4002F10CE /* Highlightable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C59413B1FB9A0B4002F10CE /* Highlightable.swift */; };
 		7C59413E1FB9A0C2002F10CE /* Enableable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C59413D1FB9A0C2002F10CE /* Enableable.swift */; };
 		7C5941401FB9A326002F10CE /* UIActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C59413F1FB9A325002F10CE /* UIActivityIndicatorView.swift */; };
+		7C8A4A011FFBD12B00C69F3C /* UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A4A001FFBD12B00C69F3C /* UIScrollView.swift */; };
 		7C9760FB1FB9A68900DC0BF8 /* UIActivityIndicatorViewSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5941411FB9A3FD002F10CE /* UIActivityIndicatorViewSpecs.swift */; };
 		E409D8E71F2BB3F0004964AE /* Configurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E409D8E61F2BB3F0004964AE /* Configurator.swift */; };
 		E43951751F2C7DFB00543B34 /* UIViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43951661F2C7C9800543B34 /* UIViewSpec.swift */; };
@@ -221,6 +222,7 @@
 		7C59413D1FB9A0C2002F10CE /* Enableable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enableable.swift; sourceTree = "<group>"; };
 		7C59413F1FB9A325002F10CE /* UIActivityIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorView.swift; sourceTree = "<group>"; };
 		7C5941411FB9A3FD002F10CE /* UIActivityIndicatorViewSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorViewSpecs.swift; sourceTree = "<group>"; };
+		7C8A4A001FFBD12B00C69F3C /* UIScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollView.swift; sourceTree = "<group>"; };
 		E409D8E61F2BB3F0004964AE /* Configurator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configurator.swift; sourceTree = "<group>"; };
 		E43951661F2C7C9800543B34 /* UIViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewSpec.swift; sourceTree = "<group>"; };
 		E44F9F4C1F2C9EC500D2683D /* CALayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CALayer.swift; sourceTree = "<group>"; };
@@ -487,6 +489,7 @@
 				E4EA601C1F69834400A2BF3A /* UIImageView.swift */,
 				E4EC0D6C1F56C1E30053621D /* UILabel.swift */,
 				E45B54231F2BBBA1001F20E3 /* UIView.swift */,
+				7C8A4A001FFBD12B00C69F3C /* UIScrollView.swift */,
 			);
 			path = UIKitExtensions;
 			sourceTree = "<group>";
@@ -779,6 +782,7 @@
 				E4EC0D6D1F56C1E30053621D /* UILabel.swift in Sources */,
 				E409D8E71F2BB3F0004964AE /* Configurator.swift in Sources */,
 				E45621461F57162100FBD730 /* UIButton.swift in Sources */,
+				7C8A4A011FFBD12B00C69F3C /* UIScrollView.swift in Sources */,
 				7C59413C1FB9A0B4002F10CE /* Highlightable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This branch includes an extension for ConfigurationSet for Base: UIScrollView and 100% unit test coverage.

The issue with `zoomScale` is solved only with documentation, but without the additional convenience method.

The branch was created from feature/UIActivityIndicatorView instead of directly from develop, because at the time I thought I might use the protocols that I moved to new files in that feature branch. In the end it was not necessary.