### PR TITLE
Feature/apply configurations on subclasses

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -125,8 +125,8 @@ struct ExampleConfigurations {
         .shadowColor(UIColor.yellow.cgColor)
         .shadowOffset(CGSize(width: 3, height: 3))
 
-    static let standardWithShadow = ExampleConfigurations.standard
-        .append(ExampleConfigurations.shadow)
+    static let standardWithShadow = standard
+        .append(shadow)
 }
 ```
 

--- a/Sources/Core/Configurator.swift
+++ b/Sources/Core/Configurator.swift
@@ -41,7 +41,6 @@ public class ConfigurationSet<Base: Configurable> {
         }
     }
 
-    @discardableResult
     public func append(_ configuration: ConfigurationSet<Base>) -> Self {
         return new(configurations: configurations + configuration.configurations)
     }

--- a/Sources/Core/Configurator.swift
+++ b/Sources/Core/Configurator.swift
@@ -45,7 +45,7 @@ public class ConfigurationSet<Base: Configurable> {
         return new(configurations: configurations + configuration.configurations)
     }
 
-    fileprivate func apply(on base: Base) -> Base {
+    func apply(on base: Base) -> Base {
         return configurations.reduce(base, { $1($0) })
     }
 

--- a/Sources/Sourcery/Stencil/SourceryScript.stencil
+++ b/Sources/Sourcery/Stencil/SourceryScript.stencil
@@ -78,7 +78,13 @@ public extension ConfigurationSet where Base: {{ type.name }} {
     {% endfor %}
     {% call createVariablesForUIViewSubclasses %}
 {% endif %}
+}
 
+extension Configurable where Self: {{ type.name }} {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<{{ type.name }}>) -> Self {
+        _ = configuration.apply(on: self as {{ type.name }})
+        return self
+    }
 }
 
 // sourcery:end

--- a/Sources/UIKitExtensionsSorceryGeneration/UIActionSheet+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIActionSheet+PropertyConfigurationSet.swift
@@ -32,5 +32,11 @@ public extension ConfigurationSet where Base: UIActionSheet {
             configurable.destructiveButtonIndex = newValue
         }
     }
+}
 
+extension Configurable where Self: UIActionSheet {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIActionSheet>) -> Self {
+        _ = configuration.apply(on: self as UIActionSheet)
+        return self
+    }
 }

--- a/Sources/UIKitExtensionsSorceryGeneration/UIActivityIndicatorView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIActivityIndicatorView+PropertyConfigurationSet.swift
@@ -23,3 +23,10 @@ public extension ConfigurationSet where Base: UIActivityIndicatorView {
     }
 
 }
+
+extension Configurable where Self: UIActivityIndicatorView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIActivityIndicatorView>) -> Self {
+        _ = configuration.apply(on: self as UIActivityIndicatorView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIAlertView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIAlertView+PropertyConfigurationSet.swift
@@ -35,3 +35,10 @@ public extension ConfigurationSet where Base: UIAlertView {
     }
 
 }
+
+extension Configurable where Self: UIAlertView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIAlertView>) -> Self {
+        _ = configuration.apply(on: self as UIAlertView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIButton+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIButton+PropertyConfigurationSet.swift
@@ -53,3 +53,10 @@ public extension ConfigurationSet where Base: UIButton {
     }
 
 }
+
+extension Configurable where Self: UIButton {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIButton>) -> Self {
+        _ = configuration.apply(on: self as UIButton)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UICollectionReusableView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UICollectionReusableView+PropertyConfigurationSet.swift
@@ -5,3 +5,10 @@ import UIKit
 public extension ConfigurationSet where Base: UICollectionReusableView {
 
 }
+
+extension Configurable where Self: UICollectionReusableView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UICollectionReusableView>) -> Self {
+        _ = configuration.apply(on: self as UICollectionReusableView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UICollectionView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UICollectionView+PropertyConfigurationSet.swift
@@ -89,3 +89,10 @@ public extension ConfigurationSet where Base: UICollectionView {
     }
 
 }
+
+extension Configurable where Self: UICollectionView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UICollectionView>) -> Self {
+        _ = configuration.apply(on: self as UICollectionView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UICollectionViewCell+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UICollectionViewCell+PropertyConfigurationSet.swift
@@ -29,3 +29,10 @@ public extension ConfigurationSet where Base: UICollectionViewCell {
     }
 
 }
+
+extension Configurable where Self: UICollectionViewCell {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UICollectionViewCell>) -> Self {
+        _ = configuration.apply(on: self as UICollectionViewCell)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIControl+PropertyConfigurationSetl.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIControl+PropertyConfigurationSetl.swift
@@ -35,3 +35,10 @@ public extension ConfigurationSet where Base: UIControl {
     }
 
 }
+
+extension Configurable where Self: UIControl {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIControl>) -> Self {
+        _ = configuration.apply(on: self as UIControl)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIDatePicker+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIDatePicker+PropertyConfigurationSet.swift
@@ -58,3 +58,10 @@ public extension ConfigurationSet where Base: UIDatePicker {
     }
 
 }
+
+extension Configurable where Self: UIDatePicker {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIDatePicker>) -> Self {
+        _ = configuration.apply(on: self as UIDatePicker)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIImageView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIImageView+PropertyConfigurationSet.swift
@@ -62,3 +62,10 @@ public extension ConfigurationSet where Base: UIImageView {
     }
 
 }
+
+extension Configurable where Self: UIImageView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIImageView>) -> Self {
+        _ = configuration.apply(on: self as UIImageView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIInputView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIInputView+PropertyConfigurationSet.swift
@@ -12,3 +12,10 @@ public extension ConfigurationSet where Base: UIInputView {
     }
 
 }
+
+extension Configurable where Self: UIInputView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIInputView>) -> Self {
+        _ = configuration.apply(on: self as UIInputView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UILabel+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UILabel+PropertyConfigurationSet.swift
@@ -116,3 +116,10 @@ public extension ConfigurationSet where Base: UILabel {
     }
 
 }
+
+extension Configurable where Self: UILabel {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UILabel>) -> Self {
+        _ = configuration.apply(on: self as UILabel)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UINavigationBar+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UINavigationBar+PropertyConfigurationSet.swift
@@ -84,3 +84,10 @@ public extension ConfigurationSet where Base: UINavigationBar {
     }
 
 }
+
+extension Configurable where Self: UINavigationBar {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UINavigationBar>) -> Self {
+        _ = configuration.apply(on: self as UINavigationBar)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIPageControl+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIPageControl+PropertyConfigurationSet.swift
@@ -42,3 +42,10 @@ public extension ConfigurationSet where Base: UIPageControl {
     }
 
 }
+
+extension Configurable where Self: UIPageControl {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIPageControl>) -> Self {
+        _ = configuration.apply(on: self as UIPageControl)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIPickerView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIPickerView+PropertyConfigurationSet.swift
@@ -22,3 +22,10 @@ public extension ConfigurationSet where Base: UIPickerView {
     }
 
 }
+
+extension Configurable where Self: UIPickerView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIPickerView>) -> Self {
+        _ = configuration.apply(on: self as UIPickerView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIPopoverBackgroundView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIPopoverBackgroundView+PropertyConfigurationSet.swift
@@ -16,3 +16,10 @@ public extension ConfigurationSet where Base: UIPopoverBackgroundView {
     }
 
 }
+
+extension Configurable where Self: UIPopoverBackgroundView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIPopoverBackgroundView>) -> Self {
+        _ = configuration.apply(on: self as UIPopoverBackgroundView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIProgressView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIProgressView+PropertyConfigurationSet.swift
@@ -51,3 +51,10 @@ public extension ConfigurationSet where Base: UIProgressView {
     }
 
 }
+
+extension Configurable where Self: UIProgressView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIProgressView>) -> Self {
+        _ = configuration.apply(on: self as UIProgressView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIRefreshControl+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIRefreshControl+PropertyConfigurationSet.swift
@@ -17,3 +17,10 @@ public extension ConfigurationSet where Base: UIRefreshControl {
     }
 
 }
+
+extension Configurable where Self: UIRefreshControl {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIRefreshControl>) -> Self {
+        _ = configuration.apply(on: self as UIRefreshControl)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIScrollView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIScrollView+PropertyConfigurationSet.swift
@@ -165,3 +165,10 @@ public extension ConfigurationSet where Base: UIScrollView {
     }
 
 }
+
+extension Configurable where Self: UIScrollView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIScrollView>) -> Self {
+        _ = configuration.apply(on: self as UIScrollView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UISearchBar+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UISearchBar+PropertyConfigurationSet.swift
@@ -142,3 +142,10 @@ public extension ConfigurationSet where Base: UISearchBar {
     }
 
 }
+
+extension Configurable where Self: UISearchBar {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UISearchBar>) -> Self {
+        _ = configuration.apply(on: self as UISearchBar)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UISegmentedControl+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UISegmentedControl+PropertyConfigurationSet.swift
@@ -29,3 +29,10 @@ public extension ConfigurationSet where Base: UISegmentedControl {
     }
 
 }
+
+extension Configurable where Self: UISegmentedControl {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UISegmentedControl>) -> Self {
+        _ = configuration.apply(on: self as UISegmentedControl)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UISlider+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UISlider+PropertyConfigurationSet.swift
@@ -61,3 +61,10 @@ public extension ConfigurationSet where Base: UISlider {
     }
 
 }
+
+extension Configurable where Self: UISlider {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UISlider>) -> Self {
+        _ = configuration.apply(on: self as UISlider)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIStackView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIStackView+PropertyConfigurationSet.swift
@@ -42,3 +42,11 @@ public extension ConfigurationSet where Base: UIStackView {
     }
 
 }
+
+@available(iOSApplicationExtension 9.0, *)
+extension Configurable where Self: UIStackView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIStackView>) -> Self {
+        _ = configuration.apply(on: self as UIStackView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIStepper+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIStepper+PropertyConfigurationSet.swift
@@ -53,3 +53,12 @@ public extension ConfigurationSet where Base: UIStepper {
     }
 
 }
+
+extension Configurable where Self: UIStepper {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIStepper>) -> Self {
+        _ = configuration.apply(on: self as UIStepper)
+        return self
+    }
+}
+
+

--- a/Sources/UIKitExtensionsSorceryGeneration/UISwitch+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UISwitch+PropertyConfigurationSet.swift
@@ -45,3 +45,10 @@ public extension ConfigurationSet where Base: UISwitch {
     }
 
 }
+
+extension Configurable where Self: UISwitch {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UISwitch>) -> Self {
+        _ = configuration.apply(on: self as UISwitch)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UITabBar+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UITabBar+PropertyConfigurationSet.swift
@@ -99,3 +99,10 @@ public extension ConfigurationSet where Base: UITabBar {
     }
 
 }
+
+extension Configurable where Self: UITabBar {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UITabBar>) -> Self {
+        _ = configuration.apply(on: self as UITabBar)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UITableView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UITableView+PropertyConfigurationSet.swift
@@ -217,3 +217,10 @@ public extension ConfigurationSet where Base: UITableView {
     }
 
 }
+
+extension Configurable where Self: UITableView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UITableView>) -> Self {
+        _ = configuration.apply(on: self as UITableView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UITableViewCell+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UITableViewCell+PropertyConfigurationSet.swift
@@ -117,3 +117,10 @@ public extension ConfigurationSet where Base: UITableViewCell {
     }
 
 }
+
+extension Configurable where Self: UITableViewCell {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UITableViewCell>) -> Self {
+        _ = configuration.apply(on: self as UITableViewCell)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UITableViewHeaderFooterView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UITableViewHeaderFooterView+PropertyConfigurationSet.swift
@@ -11,3 +11,10 @@ public extension ConfigurationSet where Base: UITableViewHeaderFooterView {
     }
 
 }
+
+extension Configurable where Self: UITableViewHeaderFooterView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UITableViewHeaderFooterView>) -> Self {
+        _ = configuration.apply(on: self as UITableViewHeaderFooterView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UITextField+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UITextField+PropertyConfigurationSet.swift
@@ -160,3 +160,10 @@ public extension ConfigurationSet where Base: UITextField {
     }
 
 }
+
+extension Configurable where Self: UITextField {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UITextField>) -> Self {
+        _ = configuration.apply(on: self as UITextField)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UITextView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UITextView+PropertyConfigurationSet.swift
@@ -114,3 +114,10 @@ public extension ConfigurationSet where Base: UITextView {
     }
 
 }
+
+extension Configurable where Self: UITextView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UITextView>) -> Self {
+        _ = configuration.apply(on: self as UITextView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIToolbar+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIToolbar+PropertyConfigurationSet.swift
@@ -43,3 +43,10 @@ public extension ConfigurationSet where Base: UIToolbar {
     }
 
 }
+
+extension Configurable where Self: UIToolbar {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIToolbar>) -> Self {
+        _ = configuration.apply(on: self as UIToolbar)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIView+PropertyConfigurationSet.swift
@@ -197,3 +197,10 @@ public extension ConfigurationSet where Base: UIView {
     }
 
 }
+
+extension Configurable where Self: UIView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIView>) -> Self {
+        _ = configuration.apply(on: self as UIView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIVisualEffectView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIVisualEffectView+PropertyConfigurationSet.swift
@@ -11,3 +11,10 @@ public extension ConfigurationSet where Base: UIVisualEffectView {
     }
 
 }
+
+extension Configurable where Self: UIVisualEffectView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIVisualEffectView>) -> Self {
+        _ = configuration.apply(on: self as UIVisualEffectView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIWebView+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIWebView+PropertyConfigurationSet.swift
@@ -100,3 +100,10 @@ public extension ConfigurationSet where Base: UIWebView {
     }
 
 }
+
+extension Configurable where Self: UIWebView {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIWebView>) -> Self {
+        _ = configuration.apply(on: self as UIWebView)
+        return self
+    }
+}

--- a/Sources/UIKitExtensionsSorceryGeneration/UIWindow+PropertyConfigurationSet.swift
+++ b/Sources/UIKitExtensionsSorceryGeneration/UIWindow+PropertyConfigurationSet.swift
@@ -24,3 +24,10 @@ public extension ConfigurationSet where Base: UIWindow {
     }
 
 }
+
+extension Configurable where Self: UIWindow {
+    @discardableResult public func apply(_ configuration: ConfigurationSet<UIWindow>) -> Self {
+        _ = configuration.apply(on: self as UIWindow)
+        return self
+    }
+}

--- a/Tests/ConfiguratorSetSpec.swift
+++ b/Tests/ConfiguratorSetSpec.swift
@@ -1,5 +1,6 @@
 import Quick
 import Nimble
+import UIKit
 @testable import ViewConfigurator
 
 class TestConfiguratable: Configurable {
@@ -70,6 +71,17 @@ class ConfiguratorSetSpec: QuickSpec {
                 
                 expect(testBuild.configuratableProperty).to(equal(1))
                 expect(testBuild.anotherProperty).toNot(equal("foo"))
+            }
+            it("Configuration sets can be applied to instances of Subclasses") {
+                let viewConfiguraition = UIView.config.backgroundColor(.red)
+                let controlConfiguration = UIControl.config.isEnabled(false)
+                
+                let button = UIButton()
+                    .apply(viewConfiguraition)
+                    .apply(controlConfiguration)
+                
+                expect(button.backgroundColor).to(equal(UIColor.red))
+                expect(button.isEnabled).to(equal(false))
             }
         }
 

--- a/ViewConfigurator.xcodeproj/project.pbxproj
+++ b/ViewConfigurator.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		E409D8E71F2BB3F0004964AE /* Configurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E409D8E61F2BB3F0004964AE /* Configurator.swift */; };
 		E43951751F2C7DFB00543B34 /* UIViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43951661F2C7C9800543B34 /* UIViewSpec.swift */; };
 		E45621481F5718E000FBD730 /* UIButtonSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45621471F5718E000FBD730 /* UIButtonSpecs.swift */; };
+		E45796AC2086382200F26617 /* SourceryScript.stencil in Resources */ = {isa = PBXBuildFile; fileRef = E45796972086382200F26617 /* SourceryScript.stencil */; };
+		E45796AE2086382200F26617 /* generate.sh in Resources */ = {isa = PBXBuildFile; fileRef = E45796992086382200F26617 /* generate.sh */; };
 		E4A317A71F56FA8300649294 /* UIControlSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A317A51F56FA1600649294 /* UIControlSpecs.swift */; };
 		E4CFDD0F2085E6AA0092EDDB /* Performance.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CFDD0E2085E6AA0092EDDB /* Performance.swift */; };
 		E4EA60311F69868A00A2BF3A /* UIImageViewSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4EA60301F69868A00A2BF3A /* UIImageViewSpecs.swift */; };
@@ -327,6 +329,9 @@
 		E409D8E61F2BB3F0004964AE /* Configurator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configurator.swift; sourceTree = "<group>"; };
 		E43951661F2C7C9800543B34 /* UIViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewSpec.swift; sourceTree = "<group>"; };
 		E45621471F5718E000FBD730 /* UIButtonSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonSpecs.swift; sourceTree = "<group>"; };
+		E45796972086382200F26617 /* SourceryScript.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SourceryScript.stencil; sourceTree = "<group>"; };
+		E45796982086382200F26617 /* SourceryGeneration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceryGeneration.swift; sourceTree = "<group>"; };
+		E45796992086382200F26617 /* generate.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = generate.sh; sourceTree = "<group>"; };
 		E4A317A51F56FA1600649294 /* UIControlSpecs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControlSpecs.swift; sourceTree = "<group>"; };
 		E4CFDD0E2085E6AA0092EDDB /* Performance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Performance.swift; sourceTree = "<group>"; };
 		E4EA60301F69868A00A2BF3A /* UIImageViewSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageViewSpecs.swift; sourceTree = "<group>"; };
@@ -378,6 +383,7 @@
 		3549BB161DA3890B00C63030 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				E45796952086382200F26617 /* Sourcery */,
 				3549BB5C1DA38AA500C63030 /* Core */,
 				7AB4AFA5206A46C500D93171 /* QuartzCoreExtensions */,
 				7AAA91D02069261D0080885E /* UIKitExtensionsSorceryGeneration */,
@@ -646,6 +652,24 @@
 			path = UIKitExtensions;
 			sourceTree = "<group>";
 		};
+		E45796952086382200F26617 /* Sourcery */ = {
+			isa = PBXGroup;
+			children = (
+				E45796962086382200F26617 /* Stencil */,
+				E45796982086382200F26617 /* SourceryGeneration.swift */,
+				E45796992086382200F26617 /* generate.sh */,
+			);
+			path = Sourcery;
+			sourceTree = "<group>";
+		};
+		E45796962086382200F26617 /* Stencil */ = {
+			isa = PBXGroup;
+			children = (
+				E45796972086382200F26617 /* SourceryScript.stencil */,
+			);
+			path = Stencil;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -884,6 +908,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E45796AC2086382200F26617 /* SourceryScript.stencil in Resources */,
+				E45796AE2086382200F26617 /* generate.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ViewConfiguratorPlayground.playground/Pages/Some Examples.xcplaygroundpage/Contents.swift
+++ b/ViewConfiguratorPlayground.playground/Pages/Some Examples.xcplaygroundpage/Contents.swift
@@ -82,16 +82,30 @@ let lazyView2 = vc2.someLazyView
 
 // Grouped Configurations
 
-let standardConfiguration = UIView.config
-    .alpha(0.8)
-    .cornerRadius(8)
-    .borderWidth(0.5)
+extension ExampleConfigurations {
+    static let standardConfiguration = UIView.config
+        .alpha(0.8)
+        .cornerRadius(8)
+        .borderWidth(0.5)
+        .backgroundColor(.red)
+        .frame(CGRect(x: 0, y: 0, width: 50, height: 50))
+    
+    static let shadowConfiguration = UIView.config
+        .shadowColor(UIColor.yellow.cgColor)
+        .shadowOffset(CGSize(width: 3, height: 3))
+    
+    static let standardWithShadowConfiguration = standardConfiguration
+        .append(shadowConfiguration)
+}
 
-let shadowConfiguration = UIView.config
-    .shadowColor(UIColor.yellow.cgColor)
-    .shadowOffset(CGSize(width: 3, height: 3))
+let standartViewWithShadow = UIView().apply(ExampleConfigurations.standardWithShadowConfiguration)
 
-let standardWithShadowConfiguration = standardConfiguration
-    .append(shadowConfiguration)
+// Apply on Subclasses
 
-let standartViewWithShadow = UIView().apply(standardWithShadowConfiguration)
+let controlConfig = UIControl.config.isEnabled(true)
+
+let button = UIButton()
+    .apply(ExampleConfigurations.standardConfiguration)
+    .apply(controlConfig)
+
+


### PR DESCRIPTION
With this pull request i am adding the possibility to apply a `ConfigurationSet<A>` to an instance of Type `B` if `B` is a Subclass of `A`.
This is solved using Code generation, because it was not possible to convey this relation between two Generic Types.